### PR TITLE
Run callbacks around scrubbing

### DIFF
--- a/lib/acts_as_scrubbable/scrub.rb
+++ b/lib/acts_as_scrubbable/scrub.rb
@@ -2,7 +2,9 @@ module ActsAsScrubbable
   module Scrub
 
     def scrub!
-      if self.class.scrubbable?
+      return unless self.class.scrubbable?
+
+      run_callbacks(:scrub) do
         _updates = {}
 
         scrubbable_fields.each do |_field, value|
@@ -20,7 +22,6 @@ module ActsAsScrubbable
 
         self.update_columns(_updates) unless _updates.empty?
       end
-
     end
   end
 end

--- a/lib/acts_as_scrubbable/scrubbable.rb
+++ b/lib/acts_as_scrubbable/scrubbable.rb
@@ -21,6 +21,7 @@ module ActsAsScrubbable
       end
 
       class_eval do
+        define_callbacks :scrub
 
         def self.scrubbable?
           true

--- a/spec/lib/acts_as_scrubbable/scrub_spec.rb
+++ b/spec/lib/acts_as_scrubbable/scrub_spec.rb
@@ -31,5 +31,10 @@ RSpec.describe ActsAsScrubbable::Scrub do
       expect(subject.address1).to be_nil
     end
 
+    it 'runs scrub callbacks' do
+      subject.scrub!
+      expect(subject.scrubbing_begun).to be(true)
+      expect(subject.scrubbing_finished).to be(true)
+    end
   end
 end

--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -16,4 +16,11 @@ class NonScrubbableModel < ActiveRecord::Base; end
 
 class ScrubbableModel < ActiveRecord::Base
   acts_as_scrubbable :first_name, :address1 => :street_address, :lat => :latitude
+  attr_accessor :scrubbing_begun, :scrubbing_finished
+  set_callback :scrub, :before do
+    self.scrubbing_begun = true
+  end
+  set_callback :scrub, :after do
+    self.scrubbing_finished = true
+  end
 end


### PR DESCRIPTION
This will allow for action to be taken on specific records before and after scrubbing, as opposed to after all scrubbing is done in the global after hook.

Specifically, this will avoid issues like https://github.com/ActsAsParanoid/acts_as_paranoid/issues/45 by allowing us to cache the `paranoid_value` and restore it afterward.