### PR TITLE
Support Faker >=1.9.2

### DIFF
--- a/lib/acts_as_scrubbable.rb
+++ b/lib/acts_as_scrubbable.rb
@@ -37,7 +37,7 @@ module ActsAsScrubbable
       :middle_name       => -> { Faker::Name.name },
       :name              => -> { Faker::Name.name },
       :email             => -> { Faker::Internet.email },
-      :name_title        => -> { Faker::Name.title },
+      :name_title        => -> { defined? Faker::Job ? Faker::Job.title : Faker::Name.title },
       :company_name      => -> { Faker::Company.name },
       :street_address    => -> { Faker::Address.street_address },
       :secondary_address => -> { Faker::Address.secondary_address },

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -2,8 +2,23 @@ ActiveRecord::Schema.define(version: 20150421224501) do
 
   create_table "scrubbable_models", force: true do |t|
     t.string   "first_name"
+    t.string   "last_name"
+    t.string   "middle_name"
+    t.string   "name"
+    t.string   "email"
+    t.string   "title"
+    t.string   "company_name"
     t.string   "address1"
+    t.string   "address2"
+    t.string   "zip_code"
+    t.string   "state"
+    t.string   "state_short"
+    t.string   "city"
     t.string   "lat"
+    t.string   "lon"
+    t.string   "username"
+    t.boolean  "active"
+    t.string   "school"
   end
 
 end

--- a/spec/lib/acts_as_scrubbable/scrub_spec.rb
+++ b/spec/lib/acts_as_scrubbable/scrub_spec.rb
@@ -5,8 +5,34 @@ RSpec.describe ActsAsScrubbable::Scrub do
   describe '.scrub' do
 
     # update_columns cannot be run on a new record
-    subject{ ScrubbableModel.new }
+    subject { ScrubbableModel.new }
     before(:each) { subject.save }
+
+    it 'scrubs all columns' do
+      subject.attributes = {
+        first_name: "Ted",
+        last_name: "Lowe",
+        middle_name: "Cassidy",
+        name: "Miss Vincenzo Smitham",
+        email: "trentdibbert@wiza.com",
+        title: "Internal Consultant",
+        company_name: "Greenfelder, Collier and Lesch",
+        address1: "86780 Watsica Flats",
+        address2: "Apt. 913",
+        zip_code: "49227",
+        state: "Ohio",
+        state_short: "OH",
+        city: "Port Hildegard",
+        lat: -79.5855309778974,
+        lon: 13.517352691513906,
+        username: "oscar.hermann",
+        active: false,
+        school: "Eastern Lebsack",
+      }
+      expect {
+        subject.scrub!
+      }.not_to raise_error
+    end
 
     it 'changes the first_name attribute when scrub is run' do
       subject.first_name = "Ted"

--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -15,7 +15,24 @@ end
 class NonScrubbableModel < ActiveRecord::Base; end
 
 class ScrubbableModel < ActiveRecord::Base
-  acts_as_scrubbable :first_name, :address1 => :street_address, :lat => :latitude
+  acts_as_scrubbable :first_name,
+    :last_name,
+    :middle_name,
+    :name,
+    :email,
+    :company_name,
+    :zip_code,
+    :state,
+    :city,
+    :username,
+    :school,
+    :title => :name_title,
+    :address1 => :street_address,
+    :address2 => :secondary_address,
+    :state_short => :state_abbr,
+    :lat => :latitude,
+    :lon => :longitude,
+    :active => :boolean
   attr_accessor :scrubbing_begun, :scrubbing_finished
   set_callback :scrub, :before do
     self.scrubbing_begun = true


### PR DESCRIPTION
In 1.9.2 (stympy/faker#1508), Faker removed the deprecated `Faker::Name.title` method in favor of `Faker::Job.title`. It was deprecated in 1.9.0.

To catch this in the future, I added a test that checks every default scrub type.