### PR TITLE
Parallelize scrubbing a single model

### DIFF
--- a/lib/acts_as_scrubbable/parallel_table_scrubber.rb
+++ b/lib/acts_as_scrubbable/parallel_table_scrubber.rb
@@ -1,0 +1,93 @@
+require "parallel"
+
+module ActsAsScrubbable
+  class ParallelTableScrubber
+    def initialize(ar_class)
+      @ar_class = ar_class
+    end
+
+    def scrub(num_batches:)
+      # Removing any find or initialize callbacks from model
+      ar_class.reset_callbacks(:initialize)
+      ar_class.reset_callbacks(:find)
+
+      queries = parallel_queries(ar_class: ar_class, num_batches: num_batches)
+      scrubbed_count = Parallel.map(queries) { |query|
+        scrubbed_count = 0
+        ActiveRecord::Base.connection_pool.with_connection do
+          relation = ar_class
+          relation = relation.send(:scrubbable_scope) if ar_class.respond_to?(:scrubbable_scope)
+          relation.where(query).find_in_batches(batch_size: 1000) do |batch|
+            ActiveRecord::Base.transaction do
+              batch.each do |obj|
+                obj.scrub!
+                scrubbed_count += 1
+              end
+            end
+          end
+        end
+        scrubbed_count
+      }.reduce(:+)
+    end
+
+    private
+
+    attr_reader :ar_class
+
+    def parallel_queries(ar_class:, num_batches:)
+      raise "Model is missing id column" if ar_class.columns.none? { |column| column.name == "id" }
+
+      id_ranges = id_ranges_for(ar_class: ar_class, count: num_batches)
+      id_ranges.map { |id_range|
+        {id: id_range[0]..id_range[1]}
+      }
+    end
+
+    # create even ID ranges for the table
+    def id_ranges_for(ar_class:, count:)
+      last_id = 2147483647 # naive maximum ID value for sorting
+      start_id = next_id(ar_class: ar_class, offset: 0) || last_id
+      return [] if start_id == last_id # no records to import
+
+      if ar_class.respond_to?(:scrubbable_scope)
+        num_records = ar_class.send(:scrubbable_scope).count
+      else
+        num_records = ar_class.count
+      end
+      record_window_size, modulus = num_records.divmod(count)
+      if record_window_size < 1
+        record_window_size = 1
+        modulus = 0
+      end
+
+      id_ranges = count.times.each_with_object([]) do |_, id_ranges|
+        next unless start_id
+
+        end_id = next_id(ar_class: ar_class, id: start_id, offset: record_window_size-1)
+        if modulus > 0
+          end_id = next_id(ar_class: ar_class, id: end_id)
+          modulus -= 1
+        end
+        id_ranges << [start_id, end_id]
+        start_id = next_id(ar_class: ar_class, id: end_id)
+      end
+
+      # just in case new records are added since we started, extend the end ID
+      id_ranges.last[1] = last_id if id_ranges.any?
+
+      id_ranges
+    end
+
+    def next_id(ar_class:, id: nil, offset: 1)
+      if ar_class.respond_to?(:scrubbable_scope)
+        collection = ar_class.send(:scrubbable_scope)
+      else
+        collection = ar_class.all
+      end
+      collection.reorder(:id)
+      collection = collection.where("#{ar_class.quoted_table_name}.id >= :id", id: id) if id
+      next_model = collection.offset(offset).first
+      next_model&.id
+    end
+  end
+end

--- a/lib/acts_as_scrubbable/tasks.rb
+++ b/lib/acts_as_scrubbable/tasks.rb
@@ -3,14 +3,12 @@ require 'rake'
 
 namespace :scrub do
 
-  desc "scrub all"
+  desc "scrub all scrubbable tables"
   task all: :environment do
-
     require 'highline/import'
     require 'term/ansicolor'
     require 'logger'
     require 'parallel'
-
 
     include Term::ANSIColor
 
@@ -27,7 +25,6 @@ namespace :scrub do
     @logger.warn "Database: ".red + "#{db_name}".white
 
     unless ENV["SKIP_CONFIRM"] == "true"
-
       answer = ask("Type '#{db_host}' to continue. \n".red + '-> '.white)
       unless answer == db_host
         @logger.error "exiting ...".red
@@ -39,23 +36,17 @@ namespace :scrub do
 
     Rails.application.eager_load! # make sure all the classes are loaded
 
-    @total_scrubbed = 0
-
     ar_classes = ActiveRecord::Base.descendants.select{|d| d.scrubbable? }.sort_by{|d| d.to_s }
 
-
-    # if the ENV variable is set
-
-    unless ENV["SCRUB_CLASSES"].blank?
+    if ENV["SCRUB_CLASSES"].present?
       class_list = ENV["SCRUB_CLASSES"].split(",")
       class_list = class_list.map {|_class_str| _class_str.constantize }
       ar_classes = ar_classes & class_list
     end
 
-    @logger.info "Srubbable Classes: #{ar_classes.join(', ')}".white
+    @logger.info "Scrubbable Classes: #{ar_classes.join(', ')}".white
 
     Parallel.each(ar_classes) do |ar_class|
-
       # Removing any find or initialize callbacks from model
       ar_class.reset_callbacks(:initialize)
       ar_class.reset_callbacks(:find)
@@ -89,6 +80,49 @@ namespace :scrub do
       @logger.info "Running after hook".red
       ActsAsScrubbable.execute_after_hook
     end
+
+    @logger.info "Scrub Complete!".white
+  end
+
+  desc "Scrub one table"
+  task :model, [:ar_class] => :environment do |_, args|
+    require 'highline/import'
+    require 'term/ansicolor'
+    require 'logger'
+    require 'acts_as_scrubbable/parallel_table_scrubber'
+
+    include Term::ANSIColor
+
+    @logger = Logger.new($stdout)
+    @logger.formatter = proc do |severity, datetime, progname, msg|
+       "#{datetime}: [#{severity}] - #{msg}\n"
+    end
+
+    db_host = ActiveRecord::Base.connection_config[:host]
+    db_name = ActiveRecord::Base.connection_config[:database]
+
+    @logger.warn "Please verify the information below to continue".red
+    @logger.warn "Host: ".red + " #{db_host}".white
+    @logger.warn "Database: ".red + "#{db_name}".white
+
+    unless ENV["SKIP_CONFIRM"] == "true"
+      answer = ask("Type '#{db_host}' to continue. \n".red + '-> '.white)
+      unless answer == db_host
+        @logger.error "exiting ...".red
+        exit
+      end
+    end
+
+    Rails.application.eager_load! # make sure all the classes are loaded
+
+    ar_class = args[:ar_class].constantize
+    @logger.info "Scrubbing #{ar_class} ...".green
+
+    num_batches = Integer(ENV.fetch("SCRUB_BATCHES", "256"))
+    scrubbed_count = ActsAsScrubbable::ParallelTableScrubber.new(ar_class).scrub(num_batches: num_batches)
+
+    @logger.info "#{scrubbed_count} #{ar_class} objects scrubbed".blue
+    ActiveRecord::Base.connection.verify!
 
     @logger.info "Scrub Complete!".white
   end


### PR DESCRIPTION
When a table has tens of millions of records, scrubbing it can take a long time. I added a rake task to parallelize that task so it can go much faster.

I'm assuming the model has an ID column, which may not always be true. For now, this felt good enough. We can always add another PR!

I arbitrarily chose 256 as the number of batches; in my testing it didn't really help to go up or down from there. I'm working on getting a larger data set to test with, though, so I may update that.

I wasn't able to add tests for this—the `NullDB` adapter doesn't allow you to actually *find* records. I just tested it on a real application.