### PR TITLE
Fixing OFFSET issue

### DIFF
--- a/lib/acts_as_scrubbable/parallel_table_scrubber.rb
+++ b/lib/acts_as_scrubbable/parallel_table_scrubber.rb
@@ -76,7 +76,7 @@ module ActsAsScrubbable
       else
         collection = ar_class.all
       end
-      collection.reorder(:id)
+      collection = collection.reorder(:id)
       collection = collection.where("#{ar_class.quoted_table_name}.id >= :id", id: id) if id
       collection.offset(offset).limit(1).pluck(:id).first
     end


### PR DESCRIPTION
In some cases, OFFSET 0 does not return the lowest IDed record within a table.  This leads to a problem where only records with IDs greater than the record returned by OFFSET 0 are run through the scrubbing process.  The fix was already in the code but not applied to the collection being evaluated so it didn't address the problem.  