### PR TITLE
Updating to handle formatting for reserved words in MySQL.

### DIFF
--- a/lib/acts_as_scrubbable/import_processor.rb
+++ b/lib/acts_as_scrubbable/import_processor.rb
@@ -14,7 +14,7 @@ module ActsAsScrubbable
       end
       ar_class.import(
         batch,
-        on_duplicate_key_update: ar_class.scrubbable_fields.keys.map { |x| "#{x} = values(#{x})" }.join(" , "),
+        on_duplicate_key_update: ar_class.scrubbable_fields.keys.map { |x| "`#{x}` = values(`#{x}`)" }.join(" , "),
         validate: false,
         timestamps: false
       )

--- a/lib/acts_as_scrubbable/version.rb
+++ b/lib/acts_as_scrubbable/version.rb
@@ -1,3 +1,3 @@
 module ActsAsScrubbable
-  VERSION = '1.2.0'
+  VERSION = '1.2.1'
 end

--- a/spec/lib/acts_as_scrubbable/import_processor_spec.rb
+++ b/spec/lib/acts_as_scrubbable/import_processor_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+RSpec.describe ActsAsScrubbable::ImportProcessor do
+  let(:ar_class) { ScrubbableModel }
+  let(:model) { ar_class.new }
+  subject { described_class.new(ar_class) }
+
+  before do
+    ar_class.extend(ImportSupport)
+  end
+
+  describe "#handle_batch" do
+    it "calls import with the correct parameters" do
+      expect(model).to receive(:scrubbed_values).and_call_original
+      expect(ar_class).to receive(:import).with(
+        [model],
+        on_duplicate_key_update: "`first_name` = values(`first_name`) , `last_name` = values(`last_name`) , `middle_name` = values(`middle_name`) , `name` = values(`name`) , `email` = values(`email`) , `company_name` = values(`company_name`) , `zip_code` = values(`zip_code`) , `state` = values(`state`) , `city` = values(`city`) , `username` = values(`username`) , `school` = values(`school`) , `title` = values(`title`) , `address1` = values(`address1`) , `address2` = values(`address2`) , `state_short` = values(`state_short`) , `lat` = values(`lat`) , `lon` = values(`lon`) , `active` = values(`active`)",
+        validate: false,
+        timestamps: false
+      )
+
+      expect(subject.send(:handle_batch, [model])).to eq 1
+    end
+  end
+end

--- a/spec/lib/acts_as_scrubbable/update_processor_spec.rb
+++ b/spec/lib/acts_as_scrubbable/update_processor_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+RSpec.describe ActsAsScrubbable::UpdateProcessor do
+  let(:ar_class) { ScrubbableModel }
+  let(:model) { ar_class.create(
+    first_name: "Ted",
+    last_name: "Lowe",
+  ) }
+  subject { described_class.new(ar_class) }
+
+  describe "#handle_batch" do
+    it "calls update with the updated attributes" do
+      expect(model).to receive(:scrubbed_values).and_call_original
+      expect(model).to receive(:update_columns).and_call_original
+
+      expect(subject.send(:handle_batch, [model])).to eq 1
+    end
+  end
+end

--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -11,6 +11,10 @@ RSpec.configure do |config|
   config.include include NullDB::RSpec::NullifiedDatabase
 end
 
+module ImportSupport
+  def import(*, **); end
+end
+
 
 class NonScrubbableModel < ActiveRecord::Base; end
 


### PR DESCRIPTION
In cases where column names uses a MySQL reserved word, the syntax generated for the UPSERT command would be invalid.  Surrounding all column references with backticks help resolve the issue.  