### PR TITLE
add before_hooks to allow cleanup before fork()

### DIFF
--- a/lib/acts_as_scrubbable.rb
+++ b/lib/acts_as_scrubbable.rb
@@ -24,6 +24,14 @@ module ActsAsScrubbable
     end
   end
 
+  def before_hook(&block)
+    @before_hook = block
+  end
+
+  def execute_before_hook
+    @before_hook.call if @before_hook
+  end
+
   def after_hook(&block)
     @after_hook = block
   end

--- a/lib/acts_as_scrubbable/task_runner.rb
+++ b/lib/acts_as_scrubbable/task_runner.rb
@@ -54,6 +54,8 @@ module ActsAsScrubbable
         ActsAsScrubbable::ArClassProcessor.new(ar_class).process(num_of_batches)
       end
       ActiveRecord::Base.connection.verify!
+
+      after_hooks
     end
 
     def after_hooks

--- a/lib/acts_as_scrubbable/task_runner.rb
+++ b/lib/acts_as_scrubbable/task_runner.rb
@@ -50,12 +50,21 @@ module ActsAsScrubbable
     end
 
     def scrub(num_of_batches: nil)
+      before_hooks
+
       Parallel.each(ar_classes) do |ar_class|
         ActsAsScrubbable::ArClassProcessor.new(ar_class).process(num_of_batches)
       end
       ActiveRecord::Base.connection.verify!
 
       after_hooks
+    end
+
+    def before_hooks
+      if ENV["SKIP_BEFOREHOOK"].blank?
+        ActsAsScrubbable.logger.info Term::ANSIColor.red("Running before hook")
+        ActsAsScrubbable.execute_before_hook
+      end
     end
 
     def after_hooks

--- a/lib/acts_as_scrubbable/tasks.rb
+++ b/lib/acts_as_scrubbable/tasks.rb
@@ -10,7 +10,6 @@ namespace :scrub do
     exit unless task_runner.confirmed_configuration?
     task_runner.extract_ar_classes
     task_runner.scrub(num_of_batches: 1)
-    task_runner.after_hooks
   end
 
   desc "Scrub one table"

--- a/lib/acts_as_scrubbable/version.rb
+++ b/lib/acts_as_scrubbable/version.rb
@@ -1,3 +1,3 @@
 module ActsAsScrubbable
-  VERSION = '1.2.2'
+  VERSION = '1.3.0'
 end

--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -1,7 +1,11 @@
 require 'nulldb/rails'
 require 'nulldb_rspec'
 
-ActiveRecord::Base.configurations.merge!("test" => {adapter: 'nulldb'})
+if ActiveRecord::Base.configurations.respond_to?(:merge!)
+  ActiveRecord::Base.configurations.merge!("test" => {adapter: 'nulldb'})
+else
+  ActiveRecord::Base.configurations = ActiveRecord::DatabaseConfigurations.new(test: {adapter: 'nulldb'})
+end
 
 NullDB.configure do |c|
   c.project_root = './spec'


### PR DESCRIPTION
Because `Parallel` calls `fork` a lot, any `at_exit` hooks can unexpectedly get called many, many times. By adding a before hook, there's a place to clean up that kind of thing before the forking and exiting happens. This is sufficient for the issue I'm solving now, but we might also want an `after_fork` hook in the future.