### PR TITLE
Back to skipping after hooks on one model

### DIFF
--- a/lib/acts_as_scrubbable/task_runner.rb
+++ b/lib/acts_as_scrubbable/task_runner.rb
@@ -49,29 +49,29 @@ module ActsAsScrubbable
       ar_classes << ar_class
     end
 
-    def scrub(num_of_batches: nil)
-      before_hooks
+    def scrub(num_of_batches: nil, skip_before_hooks: false, skip_after_hooks: false)
+      before_hooks unless skip_before_hooks
 
       Parallel.each(ar_classes) do |ar_class|
         ActsAsScrubbable::ArClassProcessor.new(ar_class).process(num_of_batches)
       end
       ActiveRecord::Base.connection.verify!
 
-      after_hooks
+      after_hooks unless skip_after_hooks
     end
 
     def before_hooks
-      if ENV["SKIP_BEFOREHOOK"].blank?
-        ActsAsScrubbable.logger.info Term::ANSIColor.red("Running before hook")
-        ActsAsScrubbable.execute_before_hook
-      end
+      return if ENV["SKIP_BEFOREHOOK"]
+
+      ActsAsScrubbable.logger.info Term::ANSIColor.red("Running before hook")
+      ActsAsScrubbable.execute_before_hook
     end
 
     def after_hooks
-      if ENV["SKIP_AFTERHOOK"].blank?
-        ActsAsScrubbable.logger.info Term::ANSIColor.red("Running after hook")
-        ActsAsScrubbable.execute_after_hook
-      end
+      return if ENV["SKIP_AFTERHOOK"]
+
+      ActsAsScrubbable.logger.info Term::ANSIColor.red("Running after hook")
+      ActsAsScrubbable.execute_after_hook
     end
   end
 end

--- a/lib/acts_as_scrubbable/tasks.rb
+++ b/lib/acts_as_scrubbable/tasks.rb
@@ -18,7 +18,7 @@ namespace :scrub do
     task_runner.prompt_db_configuration
     exit unless task_runner.confirmed_configuration?
     task_runner.set_ar_class(args[:ar_class].constantize)
-    task_runner.scrub
+    task_runner.scrub(skip_after_hooks: true)
   end
 end
 


### PR DESCRIPTION
at least by default, you can control it with an argument to the scrub() method now, as well as the env var.