### PR TITLE
Support Rails 7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.bundle
 Gemfile.lock
 
 .idea/*

--- a/acts_as_scrubbable.gemspec
+++ b/acts_as_scrubbable.gemspec
@@ -13,9 +13,9 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
   s.required_ruby_version = '~> 2.0'
 
-  s.add_runtime_dependency 'activesupport'    , '>= 4.1', '< 8'
-  s.add_runtime_dependency 'activerecord'     , '>= 4.1', '< 8'
-  s.add_runtime_dependency 'railties'         , '>= 4.1', '< 8'
+  s.add_runtime_dependency 'activesupport'    , '>= 6.1', '< 8'
+  s.add_runtime_dependency 'activerecord'     , '>= 6.1', '< 8'
+  s.add_runtime_dependency 'railties'         , '>= 6.1', '< 8'
   s.add_runtime_dependency 'faker'            , '>= 1.4'
   s.add_runtime_dependency 'highline'         , '>= 1.7'
   s.add_runtime_dependency 'term-ansicolor'   , '>= 1.3'

--- a/lib/acts_as_scrubbable/task_runner.rb
+++ b/lib/acts_as_scrubbable/task_runner.rb
@@ -13,8 +13,8 @@ module ActsAsScrubbable
     end
 
     def prompt_db_configuration
-      db_host = ActiveRecord::Base.connection_config[:host]
-      db_name = ActiveRecord::Base.connection_config[:database]
+      db_host = ActiveRecord::Base.connection_db_config.host
+      db_name = ActiveRecord::Base.connection_db_config.database
 
       ActsAsScrubbable.logger.warn Term::ANSIColor.red("Please verify the information below to continue")
       ActsAsScrubbable.logger.warn Term::ANSIColor.red("Host: ") + Term::ANSIColor.white(" #{db_host}")
@@ -22,10 +22,10 @@ module ActsAsScrubbable
     end
 
     def confirmed_configuration?
-      db_host = ActiveRecord::Base.connection_config[:host]
+      db_host = ActiveRecord::Base.connection_db_config.host
 
       unless ENV["SKIP_CONFIRM"] == "true"
-        answer = ask("Type '#{db_host}' to continue. \n".red + '-> '.white)
+        answer = ask(Term::ANSIColor.red("Type '#{db_host}' to continue. \n") + Term::ANSIColor.white("-> "))
         unless answer == db_host
           ActsAsScrubbable.logger.error Term::ANSIColor.red("exiting ...")
           return false

--- a/spec/db/database.yml
+++ b/spec/db/database.yml
@@ -1,2 +1,0 @@
-test:
-  adapter: nulldb

--- a/spec/lib/acts_as_scrubbable/task_runner_spec.rb
+++ b/spec/lib/acts_as_scrubbable/task_runner_spec.rb
@@ -1,0 +1,143 @@
+require "spec_helper"
+
+RSpec.describe ActsAsScrubbable::TaskRunner do
+  subject(:runner) { described_class.new }
+
+  let(:logger) { instance_double("Logger", error: nil, info: nil, warn: nil) }
+  before do
+    allow(ActsAsScrubbable).to receive(:logger).and_return(logger)
+  end
+
+  describe "#prompt_db_configuration" do
+    it "reports database host and name" do
+      runner.prompt_db_configuration
+      expect(logger).to have_received(:warn).with(/Host:/)
+      expect(logger).to have_received(:warn).with(/Database:/)
+    end
+  end
+
+  describe "#confirmed_configuration?" do
+    before do
+      allow(runner).to receive(:ask).and_return(answer)
+    end
+
+    context "when answer matches database host" do
+      let(:answer) { ActiveRecord::Base.connection_db_config.host }
+
+      it "is true" do
+        expect(runner).to be_confirmed_configuration
+      end
+    end
+
+    context "when answer does not match database host" do
+      let(:answer) { "anything else" }
+
+      it "is false" do
+        expect(runner).not_to be_confirmed_configuration
+      end
+    end
+  end
+
+  describe "#scrub" do
+    let(:application) { instance_double("Rails::Application", eager_load!: nil) }
+    let(:processor) { instance_double("ActsAsScrubbable::ArClassProcessor", process: nil) }
+    before do
+      allow(Rails).to receive(:application).and_return(application)
+      allow(ActsAsScrubbable::ArClassProcessor).to receive(:new).and_return(processor)
+      # RSpec mocks are not tracking calls across the forks that Parallel creates, so stub it out
+      allow(Parallel).to receive(:each) do |array, &block|
+        array.each(&block)
+      end
+    end
+
+    it "scrubs all scrubbable classes", :aggregate_failures do
+      runner.extract_ar_classes
+      runner.scrub(num_of_batches: 1)
+      expect(processor).to have_received(:process).with(1).exactly(3).times
+      expect(ActsAsScrubbable::ArClassProcessor).to have_received(:new).with(ScrubbableModel)
+      expect(ActsAsScrubbable::ArClassProcessor).to have_received(:new).with(AnotherScrubbableModel)
+      expect(ActsAsScrubbable::ArClassProcessor).to have_received(:new).with(AThirdScrubbableModel)
+      expect(ActsAsScrubbable::ArClassProcessor).not_to have_received(:new).with(NonScrubbableModel)
+    end
+
+    context "if SCRUB_CLASSES is set" do
+      before do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with("SCRUB_CLASSES").and_return(
+          "NonScrubbableModel,ScrubbableModel,AThirdScrubbableModel",
+        )
+        runner.extract_ar_classes
+      end
+
+      it "only scrubs specified scrubbable classes" do
+        runner.scrub
+        expect(processor).to have_received(:process).twice
+        expect(ActsAsScrubbable::ArClassProcessor).to have_received(:new).with(ScrubbableModel)
+        expect(ActsAsScrubbable::ArClassProcessor).to have_received(:new).with(AThirdScrubbableModel)
+        expect(ActsAsScrubbable::ArClassProcessor).not_to have_received(:new).with(AnotherScrubbableModel)
+        expect(ActsAsScrubbable::ArClassProcessor).not_to have_received(:new).with(NonScrubbableModel)
+      end
+    end
+
+    context "if a specific class is set" do
+      before do
+        runner.set_ar_class(AnotherScrubbableModel)
+      end
+
+      it "only scrubs the specified class" do
+        runner.scrub
+        expect(processor).to have_received(:process).once
+        expect(ActsAsScrubbable::ArClassProcessor).to have_received(:new).with(AnotherScrubbableModel)
+        expect(ActsAsScrubbable::ArClassProcessor).not_to have_received(:new).with(ScrubbableModel)
+        expect(ActsAsScrubbable::ArClassProcessor).not_to have_received(:new).with(AThirdScrubbableModel)
+        expect(ActsAsScrubbable::ArClassProcessor).not_to have_received(:new).with(NonScrubbableModel)
+      end
+    end
+  end
+
+  describe "#before_hooks" do
+    before do
+      allow(ActsAsScrubbable).to receive(:execute_before_hook)
+    end
+
+    it "executes before hook" do
+      runner.before_hooks
+      expect(ActsAsScrubbable).to have_received(:execute_before_hook)
+    end
+
+    context "if SKIP_BEFOREHOOK is set" do
+      before do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with("SKIP_BEFOREHOOK").and_return("true")
+      end
+
+      it "does nothing" do
+        runner.before_hooks
+        expect(ActsAsScrubbable).not_to have_received(:execute_before_hook)
+      end
+    end
+  end
+
+  describe "#after_hooks" do
+    before do
+      allow(ActsAsScrubbable).to receive(:execute_after_hook)
+    end
+
+    it "executes after hook" do
+      runner.after_hooks
+      expect(ActsAsScrubbable).to have_received(:execute_after_hook)
+    end
+
+    context "if SKIP_AFTERHOOK is set" do
+      before do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with("SKIP_AFTERHOOK").and_return("true")
+      end
+
+      it "does nothing" do
+        runner.after_hooks
+        expect(ActsAsScrubbable).not_to have_received(:execute_after_hook)
+      end
+    end
+  end
+end

--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -1,14 +1,10 @@
-require 'nulldb/rails'
-require 'nulldb_rspec'
+require "nulldb/rails"
+require "nulldb_rspec"
 
-if ActiveRecord::Base.configurations.respond_to?(:merge!)
-  ActiveRecord::Base.configurations.merge!("test" => {adapter: 'nulldb'})
-else
-  ActiveRecord::Base.configurations = ActiveRecord::DatabaseConfigurations.new(test: {adapter: 'nulldb'})
-end
+ActiveRecord::Base.configurations = ActiveRecord::DatabaseConfigurations.new(test: {adapter: "nulldb"})
 
 NullDB.configure do |c|
-  c.project_root = './spec'
+  c.project_root = "./spec"
 end
 
 RSpec.configure do |config|
@@ -48,4 +44,12 @@ class ScrubbableModel < ActiveRecord::Base
   set_callback :scrub, :after do
     self.scrubbing_finished = true
   end
+end
+
+class AnotherScrubbableModel < ActiveRecord::Base
+  acts_as_scrubbable :active => :boolean
+end
+
+class AThirdScrubbableModel < ActiveRecord::Base
+  acts_as_scrubbable :active => :boolean
 end


### PR DESCRIPTION
Rails 6.1 deprecated `connection_config` in favor of `connection_db_config`, and Rails 7 removes it. Add tests to catch this problem.