### PR TITLE
EE-795: Add support for Ruby 3

### DIFF
--- a/acts_as_scrubbable.gemspec
+++ b/acts_as_scrubbable.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.summary     = %q{Scrubbing data made easy}
   s.description = %q{ActsAsScrubbable helps you scrub your database the easy way with mock data at the ActiveRecord level}
   s.license     = "MIT"
-  s.required_ruby_version = '~> 2.0'
+  s.required_ruby_version = ['>= 2.0', '< 4.0']
 
   s.add_runtime_dependency 'activesupport'    , '>= 6.1', '< 8'
   s.add_runtime_dependency 'activerecord'     , '>= 6.1', '< 8'

--- a/lib/acts_as_scrubbable/version.rb
+++ b/lib/acts_as_scrubbable/version.rb
@@ -1,3 +1,3 @@
 module ActsAsScrubbable
-  VERSION = '2.0.0'
+  VERSION = '2.1.0'
 end


### PR DESCRIPTION
Loosen Ruby version requirement to include Ruby 3 so that we can continue to use this gem on onelife once we upgrade onelife to Ruby 3. 

[Ticket](https://jira.onemedical.com/browse/EE-795)