### PR TITLE
EE-795: Fix Ruby 3 incompability 

### DIFF
--- a/acts_as_scrubbable.gemspec
+++ b/acts_as_scrubbable.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'activerecord'     , '>= 6.1', '< 8'
   s.add_runtime_dependency 'railties'         , '>= 6.1', '< 8'
   s.add_runtime_dependency 'faker'            , '>= 1.4'
-  s.add_runtime_dependency 'highline'         , '>= 1.7'
+  s.add_runtime_dependency 'highline'         , '>= 2.1.0'
   s.add_runtime_dependency 'term-ansicolor'   , '>= 1.3'
   s.add_runtime_dependency 'parallel'         , '>= 1.6'
 


### PR DESCRIPTION
Add Ruby 3 support by updating highline rubygem to a new version fixes incompability with Ruby 3 (keyword arg lang change). 

[ticket](https://jira.onemedical.com/browse/EE-795)

Version release for this change is in this [PR](https://github.com/onemedical/acts_as_scrubbable/pull/28), which is pending successful AC. 