### PR TITLE
EE-795: Release version 2.1.1 which adds Ruby 3 support

### DIFF
--- a/lib/acts_as_scrubbable/version.rb
+++ b/lib/acts_as_scrubbable/version.rb
@@ -1,3 +1,3 @@
 module ActsAsScrubbable
-  VERSION = '2.1.0'
+  VERSION = '2.1.1'
 end


### PR DESCRIPTION
Release for this [bug fix](https://github.com/onemedical/acts_as_scrubbable/pull/27). This is pending a successful AC. 