### PR TITLE
Updating nulldb adapater for 7.1.2 compatibility

### DIFF
--- a/acts_as_scrubbable.gemspec
+++ b/acts_as_scrubbable.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'guard-rspec'  , '~> 4.6'
   s.add_development_dependency 'pry-byebug'   , '~> 3.2'
   s.add_development_dependency 'terminal-notifier-guard' , '~> 1.6'
-  s.add_development_dependency 'activerecord-nulldb-adapter', '~> 0.3'
+  s.add_development_dependency 'activerecord-nulldb-adapter', '~> 1.0'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- spec/*`.split("\n")

--- a/lib/acts_as_scrubbable/ar_class_processor.rb
+++ b/lib/acts_as_scrubbable/ar_class_processor.rb
@@ -28,7 +28,7 @@ module ActsAsScrubbable
       end
 
       ActsAsScrubbable.logger.info Term::ANSIColor.blue("#{scrubbed_count} #{ar_class} objects scrubbed")
-      ActiveRecord::Base.connection.verify!
+      ActiveRecord::Base.connection.verify! unless ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters::NullDBAdapter)
 
       ActsAsScrubbable.logger.info Term::ANSIColor.white("Scrub Complete!")
     end

--- a/lib/acts_as_scrubbable/task_runner.rb
+++ b/lib/acts_as_scrubbable/task_runner.rb
@@ -55,7 +55,7 @@ module ActsAsScrubbable
       Parallel.each(ar_classes) do |ar_class|
         ActsAsScrubbable::ArClassProcessor.new(ar_class).process(num_of_batches)
       end
-      ActiveRecord::Base.connection.verify!
+      ActiveRecord::Base.connection.verify! unless ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters::NullDBAdapter)
 
       after_hooks unless skip_after_hooks
     end

--- a/lib/acts_as_scrubbable/version.rb
+++ b/lib/acts_as_scrubbable/version.rb
@@ -1,3 +1,3 @@
 module ActsAsScrubbable
-  VERSION = '2.1.1'
+  VERSION = '2.1.2'
 end

--- a/spec/lib/acts_as_scrubbable/ar_class_processor_spec.rb
+++ b/spec/lib/acts_as_scrubbable/ar_class_processor_spec.rb
@@ -37,7 +37,6 @@ RSpec.describe ActsAsScrubbable::ArClassProcessor do
     end
 
     it "calls the expected helper classes with the expected batch size" do
-      expect(ActiveRecord::Base.connection).to receive(:verify!)
       expect(update_processor_mock).to receive(:scrub_query).with(query)
       subject.process(num_of_batches)
       expect(ActsAsScrubbable::ParallelTableScrubber).to have_received(:new).with(ar_class, 256)


### PR DESCRIPTION
The current version of nulldb doesn't support ActiveRecord 7.1.2

* Update null db
* Skip calls to `connection.verify!` when the null db adapter is in use since it does not implement the `reconnect` method.

```
 ✗ rspec spec
2023-12-13 08:58:49 -0800: [INFO] - Using Upsert
.2023-12-13 08:58:49 -0800: [INFO] - Using Update
.2023-12-13 08:58:49 -0800: [INFO] - Using Update
2023-12-13 08:58:49 -0800: [INFO] - Scrubbing ScrubbableModel ...
2023-12-13 08:58:49 -0800: [INFO] -  ScrubbableModel objects scrubbed
2023-12-13 08:58:49 -0800: [INFO] - Scrub Complete!
.2023-12-13 08:58:49 -0800: [INFO] - Using Update
2023-12-13 08:58:49 -0800: [INFO] - Scrubbing ScrubbableModel ...
2023-12-13 08:58:49 -0800: [INFO] -  ScrubbableModel objects scrubbed
2023-12-13 08:58:49 -0800: [INFO] - Scrub Complete!
.....................

Finished in 0.40945 seconds (files took 0.51792 seconds to load)
24 examples, 0 failures
```