### PR TITLE
Fix NameError from nulldb

### DIFF
--- a/lib/acts_as_scrubbable/ar_class_processor.rb
+++ b/lib/acts_as_scrubbable/ar_class_processor.rb
@@ -28,7 +28,7 @@ module ActsAsScrubbable
       end
 
       ActsAsScrubbable.logger.info Term::ANSIColor.blue("#{scrubbed_count} #{ar_class} objects scrubbed")
-      ActiveRecord::Base.connection.verify! unless ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters::NullDBAdapter)
+      ActiveRecord::Base.connection.verify! if ActiveRecord::Base.connection.respond_to?(:reconnect)
 
       ActsAsScrubbable.logger.info Term::ANSIColor.white("Scrub Complete!")
     end

--- a/lib/acts_as_scrubbable/task_runner.rb
+++ b/lib/acts_as_scrubbable/task_runner.rb
@@ -55,7 +55,7 @@ module ActsAsScrubbable
       Parallel.each(ar_classes) do |ar_class|
         ActsAsScrubbable::ArClassProcessor.new(ar_class).process(num_of_batches)
       end
-      ActiveRecord::Base.connection.verify! unless ActiveRecord::Base.connection.is_a?(ActiveRecord::ConnectionAdapters::NullDBAdapter)
+      ActiveRecord::Base.connection.verify! if ActiveRecord::Base.connection.respond_to?(:reconnect)
 
       after_hooks unless skip_after_hooks
     end

--- a/lib/acts_as_scrubbable/version.rb
+++ b/lib/acts_as_scrubbable/version.rb
@@ -1,3 +1,3 @@
 module ActsAsScrubbable
-  VERSION = '2.1.2'
+  VERSION = '2.1.3'
 end


### PR DESCRIPTION
nulldb is only loaded in the tests, so using its names in library code raised an exception:

```
NameError: uninitialized constant ActiveRecord::ConnectionAdapters::NullDBAdapter
```

We can instead key off the method that nulldb doesn't implement to fix the same issue as #32.