### PR TITLE
Update the message for undefined scrub

### DIFF
--- a/lib/acts_as_scrubbable/scrub.rb
+++ b/lib/acts_as_scrubbable/scrub.rb
@@ -16,7 +16,7 @@ module ActsAsScrubbable
           if ActsAsScrubbable.scrub_map.keys.include?(value)
             _updates[_field] = ActsAsScrubbable.scrub_map[value].call
           else
-            puts "Undefined scrub: #{value} for #{self.class}#{_field}"
+            puts "Undefined scrub: #{value} for #{self.class}.#{_field}"
            end
         end
 

--- a/spec/lib/acts_as_scrubbable/scrub_spec.rb
+++ b/spec/lib/acts_as_scrubbable/scrub_spec.rb
@@ -62,5 +62,30 @@ RSpec.describe ActsAsScrubbable::Scrub do
       expect(subject.scrubbing_begun).to be(true)
       expect(subject.scrubbing_finished).to be(true)
     end
+
+    it 'output no information when all scrubbers found' do
+      expect(STDOUT).to_not receive(:puts)
+      
+      _updates = subject.scrubbed_values
+    end
+
+    context "scrubbable" do
+      subject { MissingScrubbableModel.new }
+      
+      it 'outputs warning message' do
+        subject.first_name = "Johnny"
+        subject.last_name = "Frank"
+  
+        allow(Faker::Name).to receive(:first_name).and_return("Larry")
+        allow(Faker::Name).to receive(:last_name).and_return("Baker")
+        
+        expect(STDOUT).to receive(:puts).with('Undefined scrub: fake_first_name for MissingScrubbableModel.first_name')
+        expect(Faker::Name).to_not receive(:first_name)
+  
+        _updates = subject.scrubbed_values
+        expect(_updates[:last_name]).to eq('Baker')
+        expect(_updates[:first_name]).to be_nil
+      end
+    end
   end
 end

--- a/spec/lib/acts_as_scrubbable/task_runner_spec.rb
+++ b/spec/lib/acts_as_scrubbable/task_runner_spec.rb
@@ -53,10 +53,11 @@ RSpec.describe ActsAsScrubbable::TaskRunner do
     it "scrubs all scrubbable classes", :aggregate_failures do
       runner.extract_ar_classes
       runner.scrub(num_of_batches: 1)
-      expect(processor).to have_received(:process).with(1).exactly(3).times
+      expect(processor).to have_received(:process).with(1).exactly(4).times
       expect(ActsAsScrubbable::ArClassProcessor).to have_received(:new).with(ScrubbableModel)
       expect(ActsAsScrubbable::ArClassProcessor).to have_received(:new).with(AnotherScrubbableModel)
       expect(ActsAsScrubbable::ArClassProcessor).to have_received(:new).with(AThirdScrubbableModel)
+      expect(ActsAsScrubbable::ArClassProcessor).to have_received(:new).with(MissingScrubbableModel)
       expect(ActsAsScrubbable::ArClassProcessor).not_to have_received(:new).with(NonScrubbableModel)
     end
 

--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -53,3 +53,9 @@ end
 class AThirdScrubbableModel < ActiveRecord::Base
   acts_as_scrubbable :active => :boolean
 end
+
+class MissingScrubbableModel < ActiveRecord::Base
+  attr_accessor :first_name, :last_name
+
+  acts_as_scrubbable :last_name, :first_name => :fake_first_name
+end


### PR DESCRIPTION
Update the warning message to delineate the class vs the field.

Example of the old output which had no delination between the class and field:

```
Undefined scrub: aspen_reconciliations_fhir_resource_json for InboundFhirItemresource
```