### PR TITLE
Add Rails 7.2 and 8 into the build matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ _references:
       - "3.0"
   rails_version_prefixess: &rails_version_prefixes
     rails-version-prefix:
+      - "8.0"
       - "7.2"
       - "7.1"
       - "7.0"
@@ -94,6 +95,10 @@ workflows:
             exclude:
               - ruby-version: "3.0"
                 rails-version-prefix: "7.2"
+              - ruby-version: "3.0"
+                rails-version-prefix: "8.0"
+              - ruby-version: "3.1"
+                rails-version-prefix: "8.0"
   test-head:
     jobs:
       - test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,12 +3,13 @@ version: 2.1
 _references:
   ruby_versions: &ruby_versions
     ruby-version:
-      - "3.3.0"
-      - "3.2.2"
-      - "3.1.4"
-      - "3.0.6"
+      - "3.3"
+      - "3.2"
+      - "3.1"
+      - "3.0"
   rails_version_prefixess: &rails_version_prefixes
     rails-version-prefix:
+      - "7.2"
       - "7.1"
       - "7.0"
       - "6.1"
@@ -90,6 +91,9 @@ workflows:
             parameters:
               <<: *ruby_versions
               <<: *rails_version_prefixes
+            exclude:
+              - ruby-version: "3.0"
+                rails-version-prefix: "7.2"
   test-head:
     jobs:
       - test:
@@ -100,7 +104,9 @@ workflows:
               rails-version-prefix:
                 - main
             exclude:
-              - ruby-version: 3.0.6
+              - ruby-version: "3.0"
+                rails-version-prefix: main
+              - ruby-version: "3.1"
                 rails-version-prefix: main
       - test-ruby-head:
           name: "test-ruby-head-rails-<<matrix.rails-version-prefix>>"

--- a/acts_as_scrubbable.gemspec
+++ b/acts_as_scrubbable.gemspec
@@ -13,9 +13,9 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
   s.required_ruby_version = ['>= 2.0', '< 4.0']
 
-  s.add_runtime_dependency 'activesupport'    , '>= 6.1', '< 8'
-  s.add_runtime_dependency 'activerecord'     , '>= 6.1', '< 8'
-  s.add_runtime_dependency 'railties'         , '>= 6.1', '< 8'
+  s.add_runtime_dependency 'activesupport'    , '>= 6.1', '< 9'
+  s.add_runtime_dependency 'activerecord'     , '>= 6.1', '< 9'
+  s.add_runtime_dependency 'railties'         , '>= 6.1', '< 9'
   s.add_runtime_dependency 'faker'            , '>= 1.4'
   s.add_runtime_dependency 'highline'         , '>= 2.1.0'
   s.add_runtime_dependency 'term-ansicolor'   , '>= 1.3'


### PR DESCRIPTION
nulldb has updated, in [v1.1.1](https://github.com/nulldb/nulldb/releases/tag/v1.1.1) it now supports Rails 7.2 and 8.0.

ruby-head is still broken; I'm not sure how to fix it. ☹️ 